### PR TITLE
Remove redundant add-up-mean

### DIFF
--- a/app_saving_PLS/SPJ_PLS.m
+++ b/app_saving_PLS/SPJ_PLS.m
@@ -24,6 +24,8 @@ for tt = 1:2
     y_mat = reshape(y_half, [half_t Nk]);
     X_mat = reshape(X_half, [half_t Nk p]);
     
+    % The demean is carried out for each column, 
+    % therefore it's a within-group demean.
     y_mat = demean(y_mat);
     for pp = 1:p
         X_mat(:,:,pp) = demean( X_mat(:,:,pp) );

--- a/app_saving_PLS/master.m
+++ b/app_saving_PLS/master.m
@@ -42,13 +42,21 @@ for i = 1:N
     mean_yi = mean(yi);
     yi = bsxfun(@minus, yi, mean(yi) );
     y(index.N == i) = yi/std(yi, 1);
-    y_raw(index.N==i) = y(index.N == i) + mean_yi;
+    % Note: Jan 25, 2025
+    % The previous version (2020-04-04) used the following line:
+    % y_raw(index.N == i) = y(index.N == i) + mean_yi;
+    % This line has a redundant add-up-mean. Now it is removed.
+    % This modification of code does not change the results at all.
+    y_raw(index.N==i) = y(index.N == i);
     
     Xi = X(index.N == i, : );
     mean_Xi = mean(Xi);
     Xi = bsxfun(@minus, Xi, mean(Xi) );
     X(index.N == i, :) = Xi./repmat( std(Xi, 1), [T 1] ) ;
-    X_raw(index.N == i, :) = X(index.N == i, :) + repmat( mean(Xi), [T 1]);
+    % Note: Jan 25, 2025
+    % The previous version (2020-04-04) used the following line:
+    % X_raw(index.N == i, :) = X(index.N == i, :) + repmat( mean(Xi), [T 1]);
+    X_raw(index.N == i, :) = X(index.N == i, :);
 end
 
 ds = dataset( code, year, y, X, y_raw, X_raw );


### PR DESCRIPTION
The old version has a redundant add-up-mean after centering the data within each group. Now it is removed. 

This modification does not change the results at all. Because the two effected variables `y_raw` and `x_raw`  are only used in the half-panel jackknife (`SPJ_PLS`), inside of which all variables are again within-group demeaned.